### PR TITLE
Fix-penta-wrap

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -208,6 +208,7 @@ async function main (): Promise<void> {
   })
 
   const pentas = [
+    // { slamName: 'Small Slam', rowName: '🧪', minColumns: 3, pieces: ['darkBlue', 'orange', 'darkGreen', 'purple'] }
     { slamName: 'Small Slam', rowName: 'A', minColumns: 3, pieces: ['orange', 'brown', 'darkGreen', 'pink', 'green', 'teal', 'blue', 'purple'] },
     { slamName: 'Small Slam', rowName: 'B', minColumns: 3, pieces: ['purple', 'pink', 'yellow', 'orange', 'teal', 'brown', 'darkGreen', 'green'] },
     { slamName: 'Small Slam', rowName: 'C', minColumns: 3, pieces: ['orange', 'blue', 'pink', 'brown', 'purple', 'yellow', 'teal', 'darkGrey'] },
@@ -217,6 +218,7 @@ async function main (): Promise<void> {
     { slamName: 'Small Slam', rowName: 'G', minColumns: 3, pieces: ['orange', 'blue', 'pink', 'teal', 'brown', 'green', 'purple', 'darkGrey'] },
 
     { slamName: 'The Slam', rowName: 'A', minColumns: 5, pieces: ['orange', 'pink', 'yellow', 'darkGrey', 'green', 'brown', 'teal', 'purple', 'blue'] },
+
     /*
     { slamName: "The Slam", rowName: "B", minColumns: 5, pieces: ['', '', '', '', '', '', '', '', ''] },
     { slamName: "The Slam", rowName: "C", minColumns: 5, pieces: ['', '', '', '', '', '', '', '', ''] },

--- a/src/pages/components/Penta.tsx
+++ b/src/pages/components/Penta.tsx
@@ -131,7 +131,6 @@ export default function Penta (props: PentaProps) {
     }
     setGrid(squares)
   // ! don't put props in the dependency array
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.noBorder, props.penta, props.size])
 
   const [classes, setClasses] = useState(['grid', 'w-fit'])

--- a/src/pages/components/Penta.tsx
+++ b/src/pages/components/Penta.tsx
@@ -67,18 +67,16 @@ export default function Penta (props: PentaProps) {
         Array.isArray(block.piece.shape)
       ) {
         let shape = block.piece.shape as number[][]
+
+        // console.log('shape')
+        // console.table(shape)
+
         shape = transformBlockShape(shape,
           block.transformation,
           props.penta.borderWidth,
           true, // doTranslation
           props.penta.columns)
 
-        shape = Array2D.crop(shape,
-          props.penta.borderWidth,
-          props.penta.borderWidth,
-          5 + props.penta.borderWidth,
-          5 + props.penta.borderWidth
-        )
         for (let row = 0; row < shape.length; row++) {
           // * these exceptions to the typing are the pain from storing JSON
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -96,6 +94,7 @@ export default function Penta (props: PentaProps) {
             }
           }
         }
+        // console.table(board)
       }
     })
 
@@ -132,6 +131,7 @@ export default function Penta (props: PentaProps) {
     }
     setGrid(squares)
   // ! don't put props in the dependency array
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.noBorder, props.penta, props.size])
 
   const [classes, setClasses] = useState(['grid', 'w-fit'])

--- a/src/utils/transformations.ts
+++ b/src/utils/transformations.ts
@@ -2,6 +2,13 @@ import { type Prisma } from '@prisma/client'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const Array2D = require('array2d')
 
+function shapeInFirstColumn (shape: number[][]): boolean {
+  for (let row = 0; row < shape.length; row++) {
+    if (shape[row]?.[0] === 1) { return true }
+  }
+  return false
+}
+
 export function transformBlockShape (
   shape: number[][],
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -32,6 +39,36 @@ export function transformBlockShape (
       shape = Array2D.pad(shape, Array2D.EDGES.LEFT, 1, 0)
       shape = Array2D.pad(shape, Array2D.EDGES.BOTTOM, 1, 0)
       shape = Array2D.pad(shape, Array2D.EDGES.RIGHT, 1, 0)
+    }
+
+    // * An edge case (🥁) exists where the shape is larger than the board
+    // * requires that the shape be trimmed down to the board's size.
+    // *
+    // * The technique is to slide the piece to the left until it has
+    // * at least one square in the left most column, ensuring that
+    // * it's not occupying the rightmost columns. Then, the number
+    // * of columns on the right are chopped off. Finally, the piece
+    // * is slid back to the right the same number of times that it was
+    // * slide to the left. By doing getting the board size right, the
+    // * wrap-around behavior of the piece moving is preserved.
+
+    let slides = 0
+    while (!shapeInFirstColumn(shape)) {
+      shape = Array2D.slide(shape, Array2D.DIRECTIONS.LEFT, 1)
+      slides++
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const shapeWidth = shape[0]!.length
+    const boardWidth = (columns ?? 5) + (borderWidth * 2)
+
+    for (let i = 0; i < shapeWidth - boardWidth; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      shape = Array2D.deleteColumn(shape, shape[0]!.length - 1)
+    }
+
+    for (let slide = 0; slide < slides; slide++) {
+      shape = Array2D.slide(shape, Array2D.DIRECTIONS.RIGHT, 1)
     }
 
     for (let i = transformation.translationUp; i !== 0; (i > 0 ? i-- : i++)) { // ❤️


### PR DESCRIPTION
closes #72, maybe. it's fixed at least, now

This one was a bear to figure out. It fixes the case where a piece's width is larger than the board width. Because we iterate over the piece's shape when applying it to the board, there would be times when there was not a valid board coordinate that lined up with the piece's shape. This PR brings in special handling for this case, where the piece is slid to the left, the board trimmed on the right, and then the piece slid back into position.